### PR TITLE
Remove node engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "scripts": {
     "test": "./node_modules/jasmine-node/bin/jasmine-node tests --verbose --color --forceexit --junitreport || true"
   },
-  "engines": {
-    "node": "^5.12.0"
-  },
   "keywords": [
     "fetch",
     "fetch-reply-with",


### PR DESCRIPTION
The Node engine requirement seems very outdated and makes it impossible to install the package unless `--ignore-engines` flag is used. I used and tested the package on NodeJS v9.x and everything works correctly so, unless there are any good reasons I'm not aware of, it would be great to get this merged into your original repository and published on NPM.